### PR TITLE
Support M-; (comment-dwim function)

### DIFF
--- a/nasm-mode.el
+++ b/nasm-mode.el
@@ -677,6 +677,15 @@ is not immediately after a mnemonic; otherwise, we insert a tab."
           (end (progn (back-to-indentation) (point))))
       (and (<= start point) (<= point end)))))
 
+(defun nasm-comment-indent ()
+  "Compute desired indentation for comment on the current line."
+  comment-column)
+
+(defun nasm-insert-comment ()
+  "Insert a comment if the current line doesn’t contain one."
+  (let ((comment-insert-comment-function nil))
+    (comment-indent)))
+
 (defun nasm-comment (&optional arg)
   "Begin or edit a comment with context-sensitive placement.
 
@@ -740,6 +749,8 @@ With a prefix arg, kill the comment on the current line with
   (setf font-lock-defaults '(nasm-font-lock-keywords nil :case-fold)
         indent-line-function #'nasm-indent-line
         comment-start ";"
+        comment-indent-function 'nasm-comment-indent
+        comment-insert-comment-function 'nasm-insert-comment
         imenu-generic-expression nasm-imenu-generic-expression))
 
 (provide 'nasm-mode)


### PR DESCRIPTION
The minimum necessary changes to make the standard `M-;` (`comment-dwim`) key work similar to the current semicolon binding in NASM mode (`nasm-comment`).