### PR TITLE
Use 'symbols instead of 'words for regexp-opt

### DIFF
--- a/nasm-mode.el
+++ b/nasm-mode.el
@@ -557,7 +557,7 @@ This can be :tab, :space, or nil (do nothing)."
 (defmacro nasm--opt (keywords)
   "Prepare KEYWORDS for `looking-at'."
   `(eval-when-compile
-     (regexp-opt ,keywords 'words)))
+     (regexp-opt ,keywords 'symbols)))
 
 (defconst nasm-imenu-generic-expression
   `((nil ,(concat "^\\s-*" nasm-nonlocal-label-rexexp) 1)


### PR DESCRIPTION
When creating `nasm-full-instruction-regexp`, you [concatenate `pfx` and `ins`](https://github.com/skeeto/nasm-mode/blob/65ca6546fc395711fac5b3b4299e76c2303d43a8/nasm-mode.el#L570-L572). These are generated using [`nasm--opt`](https://github.com/skeeto/nasm-mode/blob/65ca6546fc395711fac5b3b4299e76c2303d43a8/nasm-mode.el#L557-L560), which uses `regexp-opt` with `'words` as argument.

As you can see in the [GNU emacs documentation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Regexp-Functions.html#index-regexp_002dopt), when using `'words`, it surrounds each word with `\<EXPR\>`, while using `'symbols` as parameter surrounds each word with `\_<EXPR\_>`. This should be the desired behavior, because `mov` should be highlighted, but `movABCD` and `mov_label` should not (the last one currently matches using `'words`).

Closes #12