### PR TITLE
Don't highlight constants in symbols

### DIFF
--- a/nasm-mode.el
+++ b/nasm-mode.el
@@ -547,7 +547,7 @@ This can be :tab, :space, or nil (do nothing)."
   "Regexp for `nasm-mode' for matching labels.")
 
 (defconst nasm-constant-regexp
-  "\\<$?[-+]?[0-9][-+_0-9A-Fa-fHhXxDdTtQqOoBbYyeE.]*\\>"
+  "\\_<$?[-+]?[0-9][-+_0-9A-Fa-fHhXxDdTtQqOoBbYyeE.]*\\_>"
   "Regexp for `nasm-mode' for matching numeric constants.")
 
 (defconst nasm-section-name-regexp


### PR DESCRIPTION
In the following assembly, the numbers in the labels currently get highlighted, since `label` and `1` are interpreted as separate words because of the `_`.

![image](https://github.com/skeeto/nasm-mode/assets/29655971/fed0316d-c6a3-4530-bac3-8b5e9074bec1)

After the PR:

![image](https://github.com/skeeto/nasm-mode/assets/29655971/940152a6-5e52-4528-bebe-1f6779486414)

From [Emacs manual, Backslash in Regular Expressions](https://www.gnu.org/software/emacs/manual/html_node/emacs/Regexp-Backslash.html):

> `\<`: matches the empty string, but only at the beginning of a word.
>
> `\>`: matches the empty string, but only at the end of a word.
>
> `\_<`: matches the empty string, but only at the beginning of a symbol. A symbol is a sequence of one or more symbol-constituent characters. 
>
> `\_>`: matches the empty string, but only at the end of a symbol.

---

Related to #12 and #15.